### PR TITLE
Fix Shape Handling

### DIFF
--- a/src/bodies/box2d_body_2d.cpp
+++ b/src/bodies/box2d_body_2d.cpp
@@ -415,15 +415,15 @@ TypedArray<RID> Box2DBody2D::get_collision_exceptions() const {
 
 void Box2DBody2D::set_shape_one_way_collision(int p_index, bool p_one_way, float p_margin) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
-	Box2DShapeInstance *shape = shapes[p_index];
-	shape->one_way_collision = p_one_way;
-	shape->one_way_collision_margin = p_margin;
+	Box2DShapeInstance &shape = shapes[p_index];
+	shape.one_way_collision = p_one_way;
+	shape.one_way_collision_margin = p_margin;
 }
 
 bool Box2DBody2D::get_shape_one_way_collision(int p_index) {
 	ERR_FAIL_INDEX_V(p_index, shapes.size(), false);
-	Box2DShapeInstance *shape = shapes[p_index];
-	return shape->one_way_collision;
+	Box2DShapeInstance &shape = shapes[p_index];
+	return shape.one_way_collision;
 }
 
 void Box2DBody2D::update_mass() {

--- a/src/bodies/box2d_body_2d.h
+++ b/src/bodies/box2d_body_2d.h
@@ -2,6 +2,7 @@
 
 #include "box2d_collision_object_2d.h"
 #include "box2d_direct_body_state_2d.h"
+#include <godot_cpp/templates/hash_set.hpp>
 
 class Box2DDirectBodyState2D;
 

--- a/src/bodies/box2d_collision_object_2d.cpp
+++ b/src/bodies/box2d_collision_object_2d.cpp
@@ -207,11 +207,7 @@ void Box2DCollisionObject2D::add_shape(Box2DShape2D *p_shape, const Transform2D 
 	build_shape(shape, true);
 	shapes.push_back(shape);
 
-	int index = 0;
-	for (Box2DShapeInstance *shape : shapes) {
-		shape->index = index;
-		index++;
-	}
+	reindex_all_shapes();
 }
 
 void Box2DCollisionObject2D::set_shape(int p_index, Box2DShape2D *p_shape) {
@@ -226,11 +222,7 @@ void Box2DCollisionObject2D::remove_shape(int p_index) {
 
 	shapes.remove_at(p_index);
 
-	int index = 0;
-	for (Box2DShapeInstance *shape : shapes) {
-		shape->index = index;
-		index++;
-	}
+	reindex_all_shapes();
 
 	shapes_changed();
 }
@@ -245,11 +237,7 @@ void Box2DCollisionObject2D::remove_shape(Box2DShape2D *p_shape) {
 		}
 	}
 
-	int index = 0;
-	for (Box2DShapeInstance *shape : shapes) {
-		shape->index = index;
-		index++;
-	}
+	reindex_all_shapes();
 
 	shapes_changed();
 }
@@ -257,6 +245,14 @@ void Box2DCollisionObject2D::remove_shape(Box2DShape2D *p_shape) {
 void Box2DCollisionObject2D::clear_shapes() {
 	shapes.clear();
 	shapes_changed();
+}
+
+void Box2DCollisionObject2D::reindex_all_shapes() {
+	int index = 0;
+	for (Box2DShapeInstance *shape : shapes) {
+		shape->index = index;
+		index++;
+	}
 }
 
 void Box2DCollisionObject2D::set_shape_transform(int p_index, const Transform2D &p_transform) {

--- a/src/bodies/box2d_collision_object_2d.cpp
+++ b/src/bodies/box2d_collision_object_2d.cpp
@@ -163,30 +163,30 @@ void Box2DCollisionObject2D::set_transform(const Transform2D &p_transform, bool 
 
 RID Box2DCollisionObject2D::get_shape_rid(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, shapes.size(), RID());
-	Box2DShapeInstance *shape = shapes[p_index];
-	Box2DShape2D *inst = shape->get_shape_or_null();
+	const Box2DShapeInstance &shape = shapes[p_index];
+	Box2DShape2D *inst = shape.get_shape_or_null();
 	ERR_FAIL_COND_V(!inst, RID());
 	return inst->get_rid();
 }
 
 void Box2DCollisionObject2D::set_shape_disabled(int p_index, bool p_disabled) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
-	Box2DShapeInstance *shape = shapes[p_index];
-	if (shape->disabled == p_disabled) {
+	Box2DShapeInstance &shape = shapes[p_index];
+	if (shape.disabled == p_disabled) {
 		return;
 	}
-	shape->disabled = p_disabled;
+	shape.disabled = p_disabled;
 	build_shape(shape, true);
 }
 
-void Box2DCollisionObject2D::build_shape(Box2DShapeInstance *p_shape, bool p_shapes_changed) {
+void Box2DCollisionObject2D::build_shape(Box2DShapeInstance &p_shape, bool p_shapes_changed) {
 	if (!body_exists) {
 		return;
 	}
 
 	ERR_FAIL_COND(space->locked);
 
-	p_shape->build();
+	p_shape.build();
 
 	if (p_shapes_changed) {
 		shapes_changed();
@@ -194,7 +194,7 @@ void Box2DCollisionObject2D::build_shape(Box2DShapeInstance *p_shape, bool p_sha
 }
 
 void Box2DCollisionObject2D::rebuild_all_shapes() {
-	for (Box2DShapeInstance *shape : shapes) {
+	for (Box2DShapeInstance &shape : shapes) {
 		build_shape(shape, false);
 	}
 
@@ -202,25 +202,23 @@ void Box2DCollisionObject2D::rebuild_all_shapes() {
 }
 
 void Box2DCollisionObject2D::add_shape(Box2DShape2D *p_shape, const Transform2D &p_transform, bool p_disabled) {
-	Box2DShapeInstance *shape = memnew(Box2DShapeInstance(this, p_shape, p_transform, p_disabled));
+	shapes.push_back(Box2DShapeInstance(this, p_shape, p_transform, p_disabled));
 
-	build_shape(shape, true);
-	shapes.push_back(shape);
+	build_shape(shapes[shapes.size() - 1], true);
 
 	reindex_all_shapes();
 }
 
 void Box2DCollisionObject2D::set_shape(int p_index, Box2DShape2D *p_shape) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
-	Box2DShapeInstance *shape = shapes[p_index];
-	shape->set_shape(p_shape);
+	Box2DShapeInstance &shape = shapes[p_index];
+	shape.set_shape(p_shape);
 	build_shape(shape, true);
 }
 
 void Box2DCollisionObject2D::remove_shape(int p_index) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
-	memdelete(shapes[p_index]);
 	shapes.remove_at(p_index);
 
 	reindex_all_shapes();
@@ -232,8 +230,7 @@ void Box2DCollisionObject2D::remove_shape(Box2DShape2D *p_shape) {
 	ERR_FAIL_NULL(p_shape);
 
 	for (int i = 0; i < shapes.size(); i++) {
-		if (shapes[i]->get_shape_or_null() == p_shape) {
-			memdelete(shapes[i]);
+		if (shapes[i].get_shape_or_null() == p_shape) {
 			shapes.remove_at(i);
 			i--;
 		}
@@ -245,33 +242,30 @@ void Box2DCollisionObject2D::remove_shape(Box2DShape2D *p_shape) {
 }
 
 void Box2DCollisionObject2D::clear_shapes() {
-	for (Box2DShapeInstance *shape : shapes) {
-		memdelete(shape);
-	}
 	shapes.clear();
 	shapes_changed();
 }
 
 void Box2DCollisionObject2D::reindex_all_shapes() {
 	int index = 0;
-	for (Box2DShapeInstance *shape : shapes) {
-		shape->index = index;
+	for (Box2DShapeInstance &shape : shapes) {
+		shape.index = index;
 		index++;
 	}
 }
 
 void Box2DCollisionObject2D::set_shape_transform(int p_index, const Transform2D &p_transform) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
-	Box2DShapeInstance *shape = shapes[p_index];
-	if (shape->transform == p_transform) {
+	Box2DShapeInstance &shape = shapes[p_index];
+	if (shape.transform == p_transform) {
 		return;
 	}
-	shape->transform = p_transform;
+	shape.transform = p_transform;
 	build_shape(shape, true);
 }
 
 Transform2D Box2DCollisionObject2D::get_shape_transform(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, shapes.size(), Transform2D());
-	Box2DShapeInstance *shape = shapes[p_index];
-	return shape->transform;
+	const Box2DShapeInstance &shape = shapes[p_index];
+	return shape.transform;
 }

--- a/src/bodies/box2d_collision_object_2d.cpp
+++ b/src/bodies/box2d_collision_object_2d.cpp
@@ -220,6 +220,7 @@ void Box2DCollisionObject2D::set_shape(int p_index, Box2DShape2D *p_shape) {
 void Box2DCollisionObject2D::remove_shape(int p_index) {
 	ERR_FAIL_INDEX(p_index, shapes.size());
 
+	memdelete(shapes[p_index]);
 	shapes.remove_at(p_index);
 
 	reindex_all_shapes();
@@ -232,6 +233,7 @@ void Box2DCollisionObject2D::remove_shape(Box2DShape2D *p_shape) {
 
 	for (int i = 0; i < shapes.size(); i++) {
 		if (shapes[i]->get_shape_or_null() == p_shape) {
+			memdelete(shapes[i]);
 			shapes.remove_at(i);
 			i--;
 		}
@@ -243,6 +245,9 @@ void Box2DCollisionObject2D::remove_shape(Box2DShape2D *p_shape) {
 }
 
 void Box2DCollisionObject2D::clear_shapes() {
+	for (Box2DShapeInstance *shape : shapes) {
+		memdelete(shape);
+	}
 	shapes.clear();
 	shapes_changed();
 }

--- a/src/bodies/box2d_collision_object_2d.cpp
+++ b/src/bodies/box2d_collision_object_2d.cpp
@@ -4,10 +4,6 @@
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
-Box2DCollisionObject2D::~Box2DCollisionObject2D() {
-	ERR_FAIL_COND_MSG(body_exists, "Box2D: Collision object was freed without destroying its Box2D body. This is a bug!");
-}
-
 void Box2DCollisionObject2D::destroy_body() {
 	if (b2Body_IsValid(body_id)) {
 		on_destroy_body();

--- a/src/bodies/box2d_collision_object_2d.h
+++ b/src/bodies/box2d_collision_object_2d.h
@@ -20,8 +20,6 @@ public:
 	explicit Box2DCollisionObject2D(Type p_type) :
 			type(p_type) {};
 
-	~Box2DCollisionObject2D();
-
 	Type get_type() const { return type; }
 	bool is_area() const { return type == Type::AREA; }
 

--- a/src/bodies/box2d_collision_object_2d.h
+++ b/src/bodies/box2d_collision_object_2d.h
@@ -43,9 +43,11 @@ public:
 	void set_transform(const Transform2D &p_transform, bool p_move_kinematic = false);
 	Transform2D get_transform() const { return current_transform; }
 
+	b2ShapeDef get_shape_def() const { return shape_def; }
 	void add_shape(Box2DShape2D *p_shape, const Transform2D &p_transform, bool p_disabled);
 	void set_shape(int p_index, Box2DShape2D *p_shape);
 	void remove_shape(int p_index);
+	void remove_shape(Box2DShape2D *p_shape);
 	void clear_shapes();
 
 	int32_t get_shape_count() const { return shapes.size(); }

--- a/src/bodies/box2d_collision_object_2d.h
+++ b/src/bodies/box2d_collision_object_2d.h
@@ -46,6 +46,7 @@ public:
 
 	b2BodyId get_body_id() const { return body_id; }
 	b2ShapeDef get_shape_def() const { return shape_def; }
+
 	void add_shape(Box2DShape2D *p_shape, const Transform2D &p_transform, bool p_disabled);
 	void set_shape(int p_index, Box2DShape2D *p_shape);
 	void remove_shape(int p_index);
@@ -73,7 +74,7 @@ public:
 	virtual void on_destroy_body() {};
 
 protected:
-	void build_shape(Box2DShapeInstance *p_shape, bool p_shapes_changed = true);
+	void build_shape(Box2DShapeInstance &p_shape, bool p_shapes_changed = true);
 	void rebuild_all_shapes();
 
 	Variant user_data = Variant();
@@ -83,7 +84,7 @@ protected:
 	ObjectID instance_id;
 	ObjectID canvas_instance_id;
 	Transform2D current_transform;
-	LocalVector<Box2DShapeInstance *> shapes;
+	LocalVector<Box2DShapeInstance> shapes;
 	PhysicsServer2D::BodyMode mode = PhysicsServer2D::BodyMode::BODY_MODE_STATIC;
 
 	b2BodyDef body_def = b2DefaultBodyDef();

--- a/src/bodies/box2d_collision_object_2d.h
+++ b/src/bodies/box2d_collision_object_2d.h
@@ -19,6 +19,7 @@ public:
 
 	explicit Box2DCollisionObject2D(Type p_type) :
 			type(p_type) {};
+
 	~Box2DCollisionObject2D();
 
 	Type get_type() const { return type; }
@@ -43,12 +44,14 @@ public:
 	void set_transform(const Transform2D &p_transform, bool p_move_kinematic = false);
 	Transform2D get_transform() const { return current_transform; }
 
+	b2BodyId get_body_id() const { return body_id; }
 	b2ShapeDef get_shape_def() const { return shape_def; }
 	void add_shape(Box2DShape2D *p_shape, const Transform2D &p_transform, bool p_disabled);
 	void set_shape(int p_index, Box2DShape2D *p_shape);
 	void remove_shape(int p_index);
 	void remove_shape(Box2DShape2D *p_shape);
 	void clear_shapes();
+	void reindex_all_shapes();
 
 	int32_t get_shape_count() const { return shapes.size(); }
 	void set_shape_transform(int p_index, const Transform2D &p_transform);

--- a/src/box2d_globals.h
+++ b/src/box2d_globals.h
@@ -80,42 +80,6 @@ struct ShapeGeometry {
 	}
 };
 
-/// A shape or chain id.
-struct ShapeID {
-	enum Type {
-		INVALID,
-		DEFAULT,
-		CHAIN,
-	};
-
-	Type type = Type::INVALID;
-
-	union {
-		b2ShapeId shape_id;
-		b2ChainId chain_id;
-	};
-
-	ShapeID() = default;
-
-	ShapeID(b2ShapeId p_shape_id) {
-		type = Type::DEFAULT;
-		shape_id = p_shape_id;
-	}
-
-	ShapeID(b2ChainId p_chain_id) {
-		type = Type::CHAIN;
-		chain_id = p_chain_id;
-	}
-
-	_FORCE_INLINE_ bool is_valid() {
-		return type != Type::INVALID;
-	}
-
-	_FORCE_INLINE_ static ShapeID invalid() {
-		return {};
-	}
-};
-
 /// Range for iterating body shapes.
 class BodyShapeRange {
 public:

--- a/src/box2d_globals.h
+++ b/src/box2d_globals.h
@@ -116,11 +116,6 @@ struct ShapeID {
 	}
 };
 
-struct ShapeIdAndGeometry {
-	ShapeID id = ShapeID::invalid();
-	ShapeGeometry info = ShapeGeometry::invalid();
-};
-
 /// Range for iterating body shapes.
 class BodyShapeRange {
 public:

--- a/src/servers/box2d_physics_server_2d.cpp
+++ b/src/servers/box2d_physics_server_2d.cpp
@@ -203,9 +203,9 @@ Array Box2DPhysicsServer2D::space_get_body_move_events(const RID &p_space) const
 
 // Area API
 RID Box2DPhysicsServer2D::_area_create() {
-	Box2DArea2D *body = memnew(Box2DArea2D);
-	RID rid = area_owner.make_rid(body);
-	body->set_rid(rid);
+	Box2DArea2D *area = memnew(Box2DArea2D);
+	RID rid = area_owner.make_rid(area);
+	area->set_rid(rid);
 	return rid;
 }
 
@@ -1197,12 +1197,12 @@ void Box2DPhysicsServer2D::_free_rid(const RID &p_rid) {
 		memdelete(shape);
 	} else if (body_owner.owns(p_rid)) {
 		Box2DBody2D *body = body_owner.get_or_null(p_rid);
-		body->destroy_body();
+		body->set_space(nullptr);
 		body_owner.free(p_rid);
 		bodies_to_delete.push_back(body);
 	} else if (area_owner.owns(p_rid)) {
 		Box2DArea2D *area = area_owner.get_or_null(p_rid);
-		area->destroy_body();
+		area->set_space(nullptr);
 		area_owner.free(p_rid);
 		areas_to_delete.push_back(area);
 	} else if (space_owner.owns(p_rid)) {

--- a/src/servers/box2d_physics_server_2d.cpp
+++ b/src/servers/box2d_physics_server_2d.cpp
@@ -111,6 +111,19 @@ Variant Box2DPhysicsServer2D::_shape_get_data(const RID &p_shape) const {
 	return shape->get_data();
 }
 
+bool Box2DPhysicsServer2D::_shape_collide(
+		const RID &p_shape_A,
+		const Transform2D &p_xform_A,
+		const Vector2 &p_motion_A,
+		const RID &p_shape_B,
+		const Transform2D &p_xform_B,
+		const Vector2 &p_motion_B,
+		void *p_results,
+		int32_t p_result_max,
+		int32_t *p_result_count) {
+	return false;
+}
+
 // Space API
 RID Box2DPhysicsServer2D::_space_create() {
 	Box2DSpace2D *space = memnew(Box2DSpace2D);

--- a/src/servers/box2d_physics_server_2d.cpp
+++ b/src/servers/box2d_physics_server_2d.cpp
@@ -1194,16 +1194,16 @@ void Box2DPhysicsServer2D::_free_rid(const RID &p_rid) {
 	if (shape_owner.owns(p_rid)) {
 		Box2DShape2D *shape = shape_owner.get_or_null(p_rid);
 		shape_owner.free(p_rid);
-		shapes_to_delete.push_back(shape);
+		memdelete(shape);
 	} else if (body_owner.owns(p_rid)) {
 		Box2DBody2D *body = body_owner.get_or_null(p_rid);
-		body_owner.free(p_rid);
 		body->destroy_body();
+		body_owner.free(p_rid);
 		bodies_to_delete.push_back(body);
 	} else if (area_owner.owns(p_rid)) {
 		Box2DArea2D *area = area_owner.get_or_null(p_rid);
-		area_owner.free(p_rid);
 		area->destroy_body();
+		area_owner.free(p_rid);
 		areas_to_delete.push_back(area);
 	} else if (space_owner.owns(p_rid)) {
 		Box2DSpace2D *space = space_owner.get_or_null(p_rid);
@@ -1245,11 +1245,6 @@ void Box2DPhysicsServer2D::_step(float p_step) {
 		memdelete(p_body);
 	}
 	bodies_to_delete.clear();
-
-	for (Box2DShape2D *p_shape : shapes_to_delete) {
-		memdelete(p_shape);
-	}
-	shapes_to_delete.clear();
 
 #ifdef TRACY_ENABLE
 	FrameMark;

--- a/src/servers/box2d_physics_server_2d.h
+++ b/src/servers/box2d_physics_server_2d.h
@@ -34,7 +34,7 @@ public:
 	PhysicsServer2D::ShapeType _shape_get_type(const RID &p_shape) const override;
 	Variant _shape_get_data(const RID &p_shape) const override;
 	float _shape_get_custom_solver_bias(const RID &p_shape) const override { return 0; }
-	//bool _shape_collide(const RID &p_shape_A, const Transform2D &p_xform_A, const Vector2 &p_motion_A, const RID &p_shape_B, const Transform2D &p_xform_B, const Vector2 &p_motion_B, void *p_results, int32_t p_result_max, int32_t *p_result_count) override;
+	bool _shape_collide(const RID &p_shape_A, const Transform2D &p_xform_A, const Vector2 &p_motion_A, const RID &p_shape_B, const Transform2D &p_xform_B, const Vector2 &p_motion_B, void *p_results, int32_t p_result_max, int32_t *p_result_count) override;
 
 	RID _space_create() override;
 	void _space_set_active(const RID &p_space, bool p_active) override;

--- a/src/servers/box2d_physics_server_2d.h
+++ b/src/servers/box2d_physics_server_2d.h
@@ -191,7 +191,6 @@ private:
 	bool flushing_queries;
 
 	LocalVector<Box2DBody2D *> bodies_to_delete;
-	LocalVector<Box2DShape2D *> shapes_to_delete;
 	LocalVector<Box2DArea2D *> areas_to_delete;
 
 	mutable RID_PtrOwner<Box2DSpace2D> space_owner;

--- a/src/shapes/box2d_capsule_shape_2d.cpp
+++ b/src/shapes/box2d_capsule_shape_2d.cpp
@@ -5,7 +5,7 @@ void Box2DCapsuleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_
 	if (!make_capsule(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreateCapsuleShape(p_body_id, &p_instance->shape_def, &shape);
+	b2ShapeId id = b2CreateCapsuleShape(p_body_id, &p_instance->get_shape_def(), &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_capsule_shape_2d.cpp
+++ b/src/shapes/box2d_capsule_shape_2d.cpp
@@ -1,15 +1,12 @@
 #include "box2d_capsule_shape_2d.h"
 
-ShapeIdAndGeometry Box2DCapsuleShape2D::add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const {
-	ShapeIdAndGeometry result;
-
-	result.info = get_shape_geometry(p_transform);
-	if (!result.info.is_valid()) {
-		return result;
+void Box2DCapsuleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
+	b2Capsule shape;
+	if (!make_capsule(p_instance->get_shape_transform(), data, shape)) {
+		return;
 	}
-
-	result.id = b2CreateCapsuleShape(p_body, &p_shape_def, &result.info.capsule);
-	return result;
+	b2ShapeId id = b2CreateCapsuleShape(p_body_id, &p_instance->shape_def, &shape);
+	p_instance->shape_ids.push_back(id);
 }
 
 ShapeGeometry Box2DCapsuleShape2D::get_shape_geometry(const Transform2D &p_transform) const {

--- a/src/shapes/box2d_capsule_shape_2d.cpp
+++ b/src/shapes/box2d_capsule_shape_2d.cpp
@@ -5,7 +5,8 @@ void Box2DCapsuleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_
 	if (!make_capsule(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreateCapsuleShape(p_body_id, &p_instance->get_shape_def(), &shape);
+	b2ShapeDef shape_def = p_instance->get_shape_def();
+	b2ShapeId id = b2CreateCapsuleShape(p_body_id, &shape_def, &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_capsule_shape_2d.h
+++ b/src/shapes/box2d_capsule_shape_2d.h
@@ -5,7 +5,8 @@
 
 class Box2DCapsuleShape2D : public Box2DShape2D {
 public:
-	ShapeIdAndGeometry add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const override;
+	void add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const override;
+
 	ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const override;
 	PhysicsServer2D::ShapeType get_type() const override { return PhysicsServer2D::ShapeType::SHAPE_CAPSULE; }
 

--- a/src/shapes/box2d_circle_shape_2d.cpp
+++ b/src/shapes/box2d_circle_shape_2d.cpp
@@ -1,15 +1,12 @@
 #include "box2d_circle_shape_2d.h"
 
-ShapeIdAndGeometry Box2DCircleShape2D::add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const {
-	ShapeIdAndGeometry result;
-
-	result.info = get_shape_geometry(p_transform);
-	if (!result.info.is_valid()) {
-		return result;
+void Box2DCircleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
+	b2Circle shape;
+	if (!make_circle(p_instance->get_shape_transform(), data, shape)) {
+		return;
 	}
-
-	result.id = b2CreateCircleShape(p_body, &p_shape_def, &result.info.circle);
-	return result;
+	b2ShapeId id = b2CreateCircleShape(p_body_id, &p_instance->shape_def, &shape);
+	p_instance->shape_ids.push_back(id);
 }
 
 ShapeGeometry Box2DCircleShape2D::get_shape_geometry(const Transform2D &p_transform) const {

--- a/src/shapes/box2d_circle_shape_2d.cpp
+++ b/src/shapes/box2d_circle_shape_2d.cpp
@@ -5,7 +5,8 @@ void Box2DCircleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_i
 	if (!make_circle(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreateCircleShape(p_body_id, &p_instance->get_shape_def(), &shape);
+	b2ShapeDef shape_def = p_instance->get_shape_def();
+	b2ShapeId id = b2CreateCircleShape(p_body_id, &shape_def, &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_circle_shape_2d.cpp
+++ b/src/shapes/box2d_circle_shape_2d.cpp
@@ -5,7 +5,7 @@ void Box2DCircleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_i
 	if (!make_circle(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreateCircleShape(p_body_id, &p_instance->shape_def, &shape);
+	b2ShapeId id = b2CreateCircleShape(p_body_id, &p_instance->get_shape_def(), &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_circle_shape_2d.h
+++ b/src/shapes/box2d_circle_shape_2d.h
@@ -5,7 +5,8 @@
 
 class Box2DCircleShape2D : public Box2DShape2D {
 public:
-	ShapeIdAndGeometry add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const override;
+	void add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const override;
+
 	ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const override;
 	PhysicsServer2D::ShapeType get_type() const override { return PhysicsServer2D::ShapeType::SHAPE_CIRCLE; }
 

--- a/src/shapes/box2d_concave_polygon_shape_2d.cpp
+++ b/src/shapes/box2d_concave_polygon_shape_2d.cpp
@@ -11,7 +11,7 @@ void Box2DConcavePolygonShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInsta
 	ERR_FAIL_COND(point_count % 2);
 
 	Transform2D shape_transform = p_instance->get_shape_transform();
-	b2ShapeDef shape_def = p_instance->shape_def;
+	b2ShapeDef shape_def = p_instance->get_shape_def();
 
 	for (int i = 0; i < point_count - 1; i++) {
 		b2Vec2 point_a = to_box2d(shape_transform.xform(arr[i]));

--- a/src/shapes/box2d_concave_polygon_shape_2d.cpp
+++ b/src/shapes/box2d_concave_polygon_shape_2d.cpp
@@ -1,62 +1,29 @@
 
 #include "box2d_concave_polygon_shape_2d.h"
 
-ShapeIdAndGeometry Box2DConcavePolygonShape2D::add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const {
-	ShapeIdAndGeometry result;
-
+void Box2DConcavePolygonShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
 	Variant::Type type = data.get_type();
-	ERR_FAIL_COND_V(type != Variant::PACKED_VECTOR2_ARRAY, result);
+	ERR_FAIL_COND(type != Variant::PACKED_VECTOR2_ARRAY);
 
 	PackedVector2Array arr = data;
 
 	int point_count = arr.size();
-	ERR_FAIL_COND_V_MSG(point_count < 4, result, "Box2D: Concave polygons must have at least 4 vertices");
+	ERR_FAIL_COND(point_count % 2);
 
-	if (is_polygon_clockwise(arr)) {
-		arr.reverse();
+	Transform2D shape_transform = p_instance->get_shape_transform();
+	b2ShapeDef shape_def = p_instance->shape_def;
+
+	for (int i = 0; i < point_count - 1; i++) {
+		b2Vec2 point_a = to_box2d(shape_transform.xform(arr[i]));
+		b2Vec2 point_b = to_box2d(shape_transform.xform(arr[i + 1]));
+		b2Segment segment;
+		segment.point1 = point_a;
+		segment.point2 = point_b;
+		b2ShapeId id = b2CreateSegmentShape(p_body_id, &shape_def, &segment);
+		p_instance->shape_ids.push_back(id);
 	}
-
-	b2Vec2 *points = memnew_arr(b2Vec2, point_count);
-
-	for (int i = 0; i < point_count; i++) {
-		points[i] = to_box2d(p_transform.xform(arr[i]));
-	}
-
-	b2ChainDef chain_def = b2DefaultChainDef();
-	chain_def.points = points;
-	chain_def.count = point_count;
-	chain_def.isLoop = true;
-	chain_def.userData = p_shape_def.userData;
-	chain_def.filter = p_shape_def.filter;
-	chain_def.friction = p_shape_def.friction;
-	chain_def.restitution = p_shape_def.restitution;
-	chain_def.customColor = p_shape_def.customColor;
-
-	result.id = b2CreateChain(p_body, &chain_def);
-
-	memdelete_arr(points);
-
-	return result;
 }
 
 ShapeGeometry Box2DConcavePolygonShape2D::get_shape_geometry(const Transform2D &p_transform) const {
 	ERR_FAIL_V_MSG(ShapeGeometry::invalid(), "Box2D: Overlap and shape cast queries are not supported for concave polygons.");
-}
-
-bool Box2DConcavePolygonShape2D::is_polygon_clockwise(const PackedVector2Array &p_polygon) {
-	int c = p_polygon.size();
-
-	if (c < 3) {
-		return false;
-	}
-
-	const Vector2 *p = p_polygon.ptr();
-	real_t sum = 0;
-	for (int i = 0; i < c; i++) {
-		const Vector2 &v1 = p[i];
-		const Vector2 &v2 = p[(i + 1) % c];
-		sum += (v2.x - v1.x) * (v2.y + v1.y);
-	}
-
-	return sum > 0.0f;
 }

--- a/src/shapes/box2d_concave_polygon_shape_2d.h
+++ b/src/shapes/box2d_concave_polygon_shape_2d.h
@@ -5,9 +5,8 @@
 
 class Box2DConcavePolygonShape2D : public Box2DShape2D {
 public:
-	ShapeIdAndGeometry add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const override;
+	void add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const override;
+
 	ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const override;
 	PhysicsServer2D::ShapeType get_type() const override { return PhysicsServer2D::ShapeType::SHAPE_CONCAVE_POLYGON; }
-
-	static bool is_polygon_clockwise(const PackedVector2Array &p_points);
 };

--- a/src/shapes/box2d_convex_polygon_shape_2d.cpp
+++ b/src/shapes/box2d_convex_polygon_shape_2d.cpp
@@ -1,16 +1,13 @@
 #include "box2d_convex_polygon_shape_2d.h"
 #include <godot_cpp/variant/utility_functions.hpp>
 
-ShapeIdAndGeometry Box2DConvexPolygonShape2D::add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const {
-	ShapeIdAndGeometry result;
-
-	result.info = get_shape_geometry(p_transform);
-	if (!result.info.is_valid()) {
-		return result;
+void Box2DConvexPolygonShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
+	b2Polygon shape;
+	if (!make_polygon(p_instance->get_shape_transform(), data, shape)) {
+		return;
 	}
-
-	result.id = b2CreatePolygonShape(p_body, &p_shape_def, &result.info.polygon);
-	return result;
+	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->shape_def, &shape);
+	p_instance->shape_ids.push_back(id);
 }
 
 ShapeGeometry Box2DConvexPolygonShape2D::get_shape_geometry(const Transform2D &p_transform) const {

--- a/src/shapes/box2d_convex_polygon_shape_2d.cpp
+++ b/src/shapes/box2d_convex_polygon_shape_2d.cpp
@@ -6,7 +6,8 @@ void Box2DConvexPolygonShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstan
 	if (!make_polygon(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->get_shape_def(), &shape);
+	b2ShapeDef shape_def = p_instance->get_shape_def();
+	b2ShapeId id = b2CreatePolygonShape(p_body_id, &shape_def, &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_convex_polygon_shape_2d.cpp
+++ b/src/shapes/box2d_convex_polygon_shape_2d.cpp
@@ -6,7 +6,7 @@ void Box2DConvexPolygonShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstan
 	if (!make_polygon(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->shape_def, &shape);
+	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->get_shape_def(), &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_convex_polygon_shape_2d.h
+++ b/src/shapes/box2d_convex_polygon_shape_2d.h
@@ -5,7 +5,8 @@
 
 class Box2DConvexPolygonShape2D : public Box2DShape2D {
 public:
-	ShapeIdAndGeometry add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const override;
+	void add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const override;
+
 	ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const override;
 	PhysicsServer2D::ShapeType get_type() const override { return PhysicsServer2D::ShapeType::SHAPE_CONVEX_POLYGON; }
 

--- a/src/shapes/box2d_rectangle_shape_2d.cpp
+++ b/src/shapes/box2d_rectangle_shape_2d.cpp
@@ -5,7 +5,7 @@ void Box2DRectangleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *
 	if (!make_rectangle(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->shape_def, &shape);
+	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->get_shape_def(), &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_rectangle_shape_2d.cpp
+++ b/src/shapes/box2d_rectangle_shape_2d.cpp
@@ -5,7 +5,8 @@ void Box2DRectangleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *
 	if (!make_rectangle(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->get_shape_def(), &shape);
+	b2ShapeDef shape_def = p_instance->get_shape_def();
+	b2ShapeId id = b2CreatePolygonShape(p_body_id, &shape_def, &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_rectangle_shape_2d.cpp
+++ b/src/shapes/box2d_rectangle_shape_2d.cpp
@@ -1,15 +1,12 @@
 #include "box2d_rectangle_shape_2d.h"
 
-ShapeIdAndGeometry Box2DRectangleShape2D::add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const {
-	ShapeIdAndGeometry result;
-
-	result.info = get_shape_geometry(p_transform);
-	if (!result.info.is_valid()) {
-		return result;
+void Box2DRectangleShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
+	b2Polygon shape;
+	if (!make_rectangle(p_instance->get_shape_transform(), data, shape)) {
+		return;
 	}
-
-	result.id = b2CreatePolygonShape(p_body, &p_shape_def, &result.info.polygon);
-	return result;
+	b2ShapeId id = b2CreatePolygonShape(p_body_id, &p_instance->shape_def, &shape);
+	p_instance->shape_ids.push_back(id);
 }
 
 ShapeGeometry Box2DRectangleShape2D::get_shape_geometry(const Transform2D &p_transform) const {

--- a/src/shapes/box2d_rectangle_shape_2d.h
+++ b/src/shapes/box2d_rectangle_shape_2d.h
@@ -5,7 +5,8 @@
 
 class Box2DRectangleShape2D : public Box2DShape2D {
 public:
-	ShapeIdAndGeometry add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const override;
+	void add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const override;
+
 	ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const override;
 	PhysicsServer2D::ShapeType get_type() const override { return PhysicsServer2D::ShapeType::SHAPE_RECTANGLE; }
 

--- a/src/shapes/box2d_segment_shape_2d.cpp
+++ b/src/shapes/box2d_segment_shape_2d.cpp
@@ -5,7 +5,8 @@ void Box2DSegmentShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_
 	if (!make_segment(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreateSegmentShape(p_body_id, &p_instance->get_shape_def(), &shape);
+	b2ShapeDef shape_def = p_instance->get_shape_def();
+	b2ShapeId id = b2CreateSegmentShape(p_body_id, &shape_def, &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_segment_shape_2d.cpp
+++ b/src/shapes/box2d_segment_shape_2d.cpp
@@ -5,7 +5,7 @@ void Box2DSegmentShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_
 	if (!make_segment(p_instance->get_shape_transform(), data, shape)) {
 		return;
 	}
-	b2ShapeId id = b2CreateSegmentShape(p_body_id, &p_instance->shape_def, &shape);
+	b2ShapeId id = b2CreateSegmentShape(p_body_id, &p_instance->get_shape_def(), &shape);
 	p_instance->shape_ids.push_back(id);
 }
 

--- a/src/shapes/box2d_segment_shape_2d.cpp
+++ b/src/shapes/box2d_segment_shape_2d.cpp
@@ -1,15 +1,12 @@
 #include "box2d_segment_shape_2d.h"
 
-ShapeIdAndGeometry Box2DSegmentShape2D::add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const {
-	ShapeIdAndGeometry result;
-
-	result.info = get_shape_geometry(p_transform);
-	if (!result.info.is_valid()) {
-		return result;
+void Box2DSegmentShape2D::add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
+	b2Segment shape;
+	if (!make_segment(p_instance->get_shape_transform(), data, shape)) {
+		return;
 	}
-
-	result.id = b2CreateSegmentShape(p_body, &p_shape_def, &result.info.segment);
-	return result;
+	b2ShapeId id = b2CreateSegmentShape(p_body_id, &p_instance->shape_def, &shape);
+	p_instance->shape_ids.push_back(id);
 }
 
 ShapeGeometry Box2DSegmentShape2D::get_shape_geometry(const Transform2D &p_transform) const {

--- a/src/shapes/box2d_segment_shape_2d.h
+++ b/src/shapes/box2d_segment_shape_2d.h
@@ -5,7 +5,8 @@
 
 class Box2DSegmentShape2D : public Box2DShape2D {
 public:
-	ShapeIdAndGeometry add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const override;
+	void add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const override;
+
 	ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const override;
 	PhysicsServer2D::ShapeType get_type() const override { return PhysicsServer2D::ShapeType::SHAPE_SEGMENT; }
 

--- a/src/shapes/box2d_shape_2d.cpp
+++ b/src/shapes/box2d_shape_2d.cpp
@@ -2,20 +2,39 @@
 #include "../bodies/box2d_collision_object_2d.h"
 
 Box2DShape2D::~Box2DShape2D() {
+	remove_from_all_bodies();
+}
+
+void Box2DShape2D::remove_from_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
+	for (b2ShapeId shape_id : p_instance->shape_ids) {
+		b2DestroyShape(shape_id, false);
+	}
 }
 
 void Box2DShape2D::set_data(const Variant &p_data) {
 	data = p_data;
-
-	if (!validate_data(p_data)) {
-		return;
-	}
-
 	update_instances();
 }
 
 void Box2DShape2D::update_instances() {
-	for (Box2DShapeInstance *instance : instances) {
-		instance->build();
+	for (const auto &[owner, ref_count] : ref_counts_by_body) {
+		owner->shapes_changed();
+	}
+}
+
+void Box2DShape2D::add_body_reference(Box2DCollisionObject2D *p_owner) {
+	ref_counts_by_body[p_owner]++;
+}
+
+void Box2DShape2D::remove_body_reference(Box2DCollisionObject2D *p_owner) {
+	if (--ref_counts_by_body[p_owner] <= 0) {
+		ref_counts_by_body.erase(p_owner);
+	}
+}
+
+void Box2DShape2D::remove_from_all_bodies() {
+	const auto ref_counts_by_owner_copy = ref_counts_by_body;
+	for (const auto &[owner, ref_count] : ref_counts_by_owner_copy) {
+		owner->remove_shape(this);
 	}
 }

--- a/src/shapes/box2d_shape_2d.cpp
+++ b/src/shapes/box2d_shape_2d.cpp
@@ -1,7 +1,21 @@
 #include "box2d_shape_2d.h"
+#include "../bodies/box2d_collision_object_2d.h"
 
 Box2DShape2D::~Box2DShape2D() {
-	for (Box2DShapeInstance *inst : instances) {
-		inst->set_shape(nullptr);
+}
+
+void Box2DShape2D::set_data(const Variant &p_data) {
+	data = p_data;
+
+	if (!validate_data(p_data)) {
+		return;
+	}
+
+	update_instances();
+}
+
+void Box2DShape2D::update_instances() {
+	for (Box2DShapeInstance *instance : instances) {
+		instance->build();
 	}
 }

--- a/src/shapes/box2d_shape_2d.cpp
+++ b/src/shapes/box2d_shape_2d.cpp
@@ -7,8 +7,11 @@ Box2DShape2D::~Box2DShape2D() {
 
 void Box2DShape2D::remove_from_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const {
 	for (b2ShapeId shape_id : p_instance->shape_ids) {
-		b2DestroyShape(shape_id, false);
+		if (b2Shape_IsValid(shape_id)) {
+			b2DestroyShape(shape_id, false);
+		}
 	}
+	p_instance->shape_ids.clear();
 }
 
 void Box2DShape2D::set_data(const Variant &p_data) {

--- a/src/shapes/box2d_shape_2d.h
+++ b/src/shapes/box2d_shape_2d.h
@@ -8,28 +8,32 @@
 using namespace godot;
 
 class Box2DShapeInstance;
+class Box2DCollisionObject2D;
 
-/// Builder class for shapes.
 class Box2DShape2D {
 public:
-	virtual ~Box2DShape2D();
-
-	virtual ShapeIdAndGeometry add_to_body(b2BodyId p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const = 0;
+	virtual Box2DShapeInstance *add_to_body(Box2DCollisionObject2D *p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const = 0;
+	virtual void remove_from_body(Box2DCollisionObject2D *p_body, Box2DShapeInstance *p_instance) = 0;
 
 	/// Return the shape geometry modified by the given transform.
 	virtual ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const = 0;
 
 	virtual PhysicsServer2D::ShapeType get_type() const = 0;
 
-	RID get_rid() const { return rid; }
 	void set_rid(const RID &p_rid) { rid = p_rid; }
-	void set_data(const Variant &p_data) { data = p_data; }
+	RID get_rid() const { return rid; }
+
+	void set_data(const Variant &p_data);
 	Variant get_data() const { return data; }
 
 	void add_instance(Box2DShapeInstance *p_shape) { instances.insert(p_shape); }
 	void remove_instance(Box2DShapeInstance *p_shape) { instances.erase(p_shape); }
 
 protected:
+	void update_instances();
+
+	virtual bool validate_data(const Variant &p_data) = 0;
+
 	RID rid;
 	Variant data;
 	HashSet<Box2DShapeInstance *> instances;

--- a/src/shapes/box2d_shape_2d.h
+++ b/src/shapes/box2d_shape_2d.h
@@ -3,7 +3,7 @@
 #include "../box2d_globals.h"
 #include "box2d_shape_instance.h"
 #include <godot_cpp/classes/physics_server2d.hpp>
-#include <godot_cpp/templates/hash_set.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
 
 using namespace godot;
 
@@ -12,8 +12,11 @@ class Box2DCollisionObject2D;
 
 class Box2DShape2D {
 public:
-	virtual Box2DShapeInstance *add_to_body(Box2DCollisionObject2D *p_body, const Transform2D &p_transform, const b2ShapeDef &p_shape_def) const = 0;
-	virtual void remove_from_body(Box2DCollisionObject2D *p_body, Box2DShapeInstance *p_instance) = 0;
+	virtual ~Box2DShape2D();
+
+	/// Note: This does not validate data
+	virtual void add_to_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const = 0;
+	virtual void remove_from_body(b2BodyId p_body_id, Box2DShapeInstance *p_instance) const;
 
 	/// Return the shape geometry modified by the given transform.
 	virtual ShapeGeometry get_shape_geometry(const Transform2D &p_transform) const = 0;
@@ -26,15 +29,14 @@ public:
 	void set_data(const Variant &p_data);
 	Variant get_data() const { return data; }
 
-	void add_instance(Box2DShapeInstance *p_shape) { instances.insert(p_shape); }
-	void remove_instance(Box2DShapeInstance *p_shape) { instances.erase(p_shape); }
+	void add_body_reference(Box2DCollisionObject2D *p_owner);
+	void remove_body_reference(Box2DCollisionObject2D *p_owner);
+	void remove_from_all_bodies();
 
 protected:
 	void update_instances();
 
-	virtual bool validate_data(const Variant &p_data) = 0;
-
 	RID rid;
 	Variant data;
-	HashSet<Box2DShapeInstance *> instances;
+	HashMap<Box2DCollisionObject2D *, int> ref_counts_by_body;
 };

--- a/src/shapes/box2d_shape_instance.cpp
+++ b/src/shapes/box2d_shape_instance.cpp
@@ -1,32 +1,42 @@
 #include "box2d_shape_instance.h"
 #include "../bodies/box2d_collision_object_2d.h"
 
-void Box2DShapeInstance::set_shape(Box2DShape2D *p_shape) {
+Box2DShapeInstance::Box2DShapeInstance(Box2DCollisionObject2D *p_body,
+		Box2DShape2D *p_shape,
+		const Transform2D &p_transform,
+		bool p_disabled) :
+		body(p_body),
+		shape(p_shape),
+		transform(p_transform),
+		disabled(p_disabled) {
 	if (shape) {
-		shape->remove_instance(this);
+		shape->add_body_reference(body);
 	}
+}
 
-	if (!p_shape) {
-		shape = nullptr;
+Box2DShapeInstance::~Box2DShapeInstance() {
+	if (shape) {
 		return;
 	}
-
-	shape = p_shape;
-	p_shape->add_instance(this);
+	shape->remove_body_reference(body);
+	shape->remove_from_body(body->get_body_id(), this);
 }
 
 void Box2DShapeInstance::build() {
 	ERR_FAIL_COND(!shape);
 	ERR_FAIL_COND(!body);
 
-	shape->remove_from_body(body, this);
+	shape->remove_from_body(body->get_body_id(), this);
 
 	if (disabled) {
 		return;
 	}
 
+	shape->add_to_body(body->get_body_id(), this);
+}
+
+Transform2D Box2DShapeInstance::get_shape_transform() const {
 	Transform2D parent_transform = body->get_transform();
 	Transform2D parent_scale_and_skew = Transform2D(0.0, parent_transform.get_scale(), parent_transform.get_skew(), Vector2());
-
-	shape->add_to_body(body, parent_scale_and_skew * transform, body->get_shape_def());
+	return parent_transform * transform;
 }

--- a/src/shapes/box2d_shape_instance.cpp
+++ b/src/shapes/box2d_shape_instance.cpp
@@ -40,3 +40,9 @@ Transform2D Box2DShapeInstance::get_shape_transform() const {
 	Transform2D parent_scale_and_skew = Transform2D(0.0, parent_transform.get_scale(), parent_transform.get_skew(), Vector2());
 	return parent_transform * transform;
 }
+
+b2ShapeDef Box2DShapeInstance::get_shape_def() const {
+	b2ShapeDef shape_def = body->get_shape_def();
+	shape_def.userData = shape;
+	return shape_def;
+}

--- a/src/shapes/box2d_shape_instance.cpp
+++ b/src/shapes/box2d_shape_instance.cpp
@@ -15,7 +15,7 @@ Box2DShapeInstance::Box2DShapeInstance(Box2DCollisionObject2D *p_body,
 }
 
 Box2DShapeInstance::~Box2DShapeInstance() {
-	if (shape) {
+	if (!shape) {
 		return;
 	}
 	shape->remove_body_reference(body);

--- a/src/shapes/box2d_shape_instance.cpp
+++ b/src/shapes/box2d_shape_instance.cpp
@@ -1,7 +1,8 @@
 #include "box2d_shape_instance.h"
 #include "../bodies/box2d_collision_object_2d.h"
 
-Box2DShapeInstance::Box2DShapeInstance(Box2DCollisionObject2D *p_body,
+Box2DShapeInstance::Box2DShapeInstance(
+		Box2DCollisionObject2D *p_body,
 		Box2DShape2D *p_shape,
 		const Transform2D &p_transform,
 		bool p_disabled) :
@@ -38,11 +39,11 @@ void Box2DShapeInstance::build() {
 Transform2D Box2DShapeInstance::get_shape_transform() const {
 	Transform2D parent_transform = body->get_transform();
 	Transform2D parent_scale_and_skew = Transform2D(0.0, parent_transform.get_scale(), parent_transform.get_skew(), Vector2());
-	return parent_transform * transform;
+	return parent_scale_and_skew * transform;
 }
 
 b2ShapeDef Box2DShapeInstance::get_shape_def() const {
 	b2ShapeDef shape_def = body->get_shape_def();
-	shape_def.userData = shape;
+	shape_def.userData = (void *)this;
 	return shape_def;
 }

--- a/src/shapes/box2d_shape_instance.cpp
+++ b/src/shapes/box2d_shape_instance.cpp
@@ -16,11 +16,11 @@ Box2DShapeInstance::Box2DShapeInstance(
 }
 
 Box2DShapeInstance::~Box2DShapeInstance() {
-	if (!shape) {
+	if (!shape || !body) {
 		return;
 	}
-	shape->remove_body_reference(body);
 	shape->remove_from_body(body->get_body_id(), this);
+	shape->remove_body_reference(body);
 }
 
 void Box2DShapeInstance::build() {

--- a/src/shapes/box2d_shape_instance.h
+++ b/src/shapes/box2d_shape_instance.h
@@ -3,30 +3,43 @@
 #include "box2d_shape_2d.h"
 
 class Box2DShape2D;
+class Box2DCollisionObject2D;
 
 class Box2DShapeInstance {
 public:
+	explicit Box2DShapeInstance(Box2DCollisionObject2D *p_body,
+			Box2DShape2D *p_shape,
+			const Transform2D &p_transform,
+			bool p_disabled) :
+			body(p_body),
+			shape(p_shape),
+			transform(p_transform),
+			disabled(p_disabled) {
+		if (p_shape) {
+			p_shape->add_instance(this);
+		}
+	}
+
+	~Box2DShapeInstance() {
+		if (shape) {
+			shape->remove_instance(this);
+		}
+	}
+
 	int index = -1;
-	ShapeID shape_id;
-	ShapeGeometry shape_geometry;
+	b2ShapeDef shape_def;
+
 	Transform2D transform;
 	bool disabled = false;
 	bool one_way_collision = false;
 	float one_way_collision_margin = 0.0;
 
 	void set_shape(Box2DShape2D *p_shape);
-
 	Box2DShape2D *get_shape_or_null() const { return shape; }
 
-	void build(b2BodyId p_body, const Transform2D &p_transform, b2ShapeDef p_shape_def);
-
-	void destroy();
-
-	~Box2DShapeInstance() {
-		destroy();
-		set_shape(nullptr);
-	}
+	void build();
 
 private:
+	Box2DCollisionObject2D *body = nullptr;
 	Box2DShape2D *shape = nullptr;
 };

--- a/src/shapes/box2d_shape_instance.h
+++ b/src/shapes/box2d_shape_instance.h
@@ -16,7 +16,6 @@ public:
 	~Box2DShapeInstance();
 
 	int index = -1;
-
 	Transform2D transform;
 	bool disabled = false;
 	bool one_way_collision = false;

--- a/src/shapes/box2d_shape_instance.h
+++ b/src/shapes/box2d_shape_instance.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "box2d_shape_2d.h"
+#include <godot_cpp/templates/local_vector.hpp>
 
 class Box2DShape2D;
 class Box2DCollisionObject2D;
@@ -10,21 +11,9 @@ public:
 	explicit Box2DShapeInstance(Box2DCollisionObject2D *p_body,
 			Box2DShape2D *p_shape,
 			const Transform2D &p_transform,
-			bool p_disabled) :
-			body(p_body),
-			shape(p_shape),
-			transform(p_transform),
-			disabled(p_disabled) {
-		if (p_shape) {
-			p_shape->add_instance(this);
-		}
-	}
+			bool p_disabled);
 
-	~Box2DShapeInstance() {
-		if (shape) {
-			shape->remove_instance(this);
-		}
-	}
+	~Box2DShapeInstance();
 
 	int index = -1;
 	b2ShapeDef shape_def;
@@ -34,8 +23,12 @@ public:
 	bool one_way_collision = false;
 	float one_way_collision_margin = 0.0;
 
-	void set_shape(Box2DShape2D *p_shape);
+	LocalVector<b2ShapeId> shape_ids;
+
+	void set_shape(Box2DShape2D *p_shape) { shape = p_shape; }
 	Box2DShape2D *get_shape_or_null() const { return shape; }
+
+	Transform2D get_shape_transform() const;
 
 	void build();
 

--- a/src/shapes/box2d_shape_instance.h
+++ b/src/shapes/box2d_shape_instance.h
@@ -16,7 +16,6 @@ public:
 	~Box2DShapeInstance();
 
 	int index = -1;
-	b2ShapeDef shape_def;
 
 	Transform2D transform;
 	bool disabled = false;
@@ -29,6 +28,7 @@ public:
 	Box2DShape2D *get_shape_or_null() const { return shape; }
 
 	Transform2D get_shape_transform() const;
+	b2ShapeDef get_shape_def() const;
 
 	void build();
 

--- a/src/shapes/box2d_shape_instance.h
+++ b/src/shapes/box2d_shape_instance.h
@@ -13,6 +13,8 @@ public:
 			const Transform2D &p_transform,
 			bool p_disabled);
 
+	Box2DShapeInstance() = default;
+
 	~Box2DShapeInstance();
 
 	int index = -1;

--- a/src/spaces/box2d_space_2d.cpp
+++ b/src/spaces/box2d_space_2d.cpp
@@ -131,8 +131,10 @@ Box2DSpace2D::~Box2DSpace2D() {
 		memdelete(direct_state);
 	}
 
-	ERR_FAIL_COND(!b2World_IsValid(world_id));
-	b2DestroyWorld(world_id);
+	if (b2World_IsValid(world_id)) {
+		b2DestroyWorld(world_id);
+	}
+
 	world_id = b2_nullWorldId;
 }
 

--- a/src/spaces/box2d_space_2d.cpp
+++ b/src/spaces/box2d_space_2d.cpp
@@ -164,7 +164,11 @@ void Box2DSpace2D::sync_state() {
 
 	for (int i = 0; i < body_events.moveCount; ++i) {
 		const b2BodyMoveEvent *event = body_events.moveEvents + i;
-		Box2DBody2D *body = static_cast<Box2DBody2D *>(event->userData);
+		Box2DCollisionObject2D *object = static_cast<Box2DCollisionObject2D *>(event->userData);
+		if (object->is_area()) {
+			continue;
+		}
+		Box2DBody2D *body = static_cast<Box2DBody2D *>(object);
 		body->sync_state(event->transform, event->fellAsleep);
 	}
 }


### PR DESCRIPTION
Previously, shape instances would not update when the source shape was modified or deleted. This PR changes the handling to be in line with Godot physics.